### PR TITLE
Update the runtime version from 47 to 50, and more

### DIFF
--- a/io.github.ilius.pyglossary.metainfo.xml
+++ b/io.github.ilius.pyglossary.metainfo.xml
@@ -3,9 +3,11 @@
   <id>io.github.ilius.pyglossary</id>
 
   <name>PyGlossary</name>
-  <summary>A tool for converting dictionary files aka glossaries.</summary>
+  <summary>A tool for converting dictionary files aka glossaries</summary>
 
-  <developer_name>Saeed Rasooli</developer_name>
+  <developer id="io.github.ilius">
+    <name>Saeed Rasooli</name>
+  </developer>
 
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
@@ -23,6 +25,7 @@
 
   <url type="homepage">https://github.com/ilius/pyglossary</url>
   <url type="bugtracker">https://github.com/ilius/pyglossary/issues/</url>
+  <url type="vcs-browser">https://github.com/ilius/pyglossary</url>
 
   <content_rating type="oars-1.1"/>
 
@@ -34,30 +37,15 @@
   </screenshots>
 
   <releases>
-    <release version="5.0.7" date="2025-01-25">
-      <description></description>
-    </release>
-    <release version="5.0.6" date="2025-01-12">
-      <description/>
-    </release>
-    <release version="5.0.4" date="2025-01-05">
-      <description/>
-    </release>
-    <release version="5.0.3" date="2024-12-30">
-      <description/>
-    </release>
-    <release version="5.0.1" date="2024-12-19">
-      <description/>
-    </release>
-    <release version="5.0.0" date="2024-12-14">
-      <description/>
-    </release>
-    <release version="4.7.1" date="2024-09-23">
-      <description/>
-    </release>
-    <release version="4.7.0" date="2024-06-18">
-      <description/>
-    </release>
+    <release version="5.3.0" date="2026-03-29"/>
+    <release version="5.0.7" date="2025-01-25"/>
+    <release version="5.0.6" date="2025-01-12"/>
+    <release version="5.0.4" date="2025-01-05"/>
+    <release version="5.0.3" date="2024-12-30"/>
+    <release version="5.0.1" date="2024-12-19"/>
+    <release version="5.0.0" date="2024-12-14"/>
+    <release version="4.7.1" date="2024-09-23"/>
+    <release version="4.7.0" date="2024-06-18"/>
     <release version="4.6.1" date="2023-03-10"/>
     <release version="4.6.0" date="2023-03-07"/>
     <release version="4.5.0" date="2022-02-05"/>

--- a/io.github.ilius.pyglossary.yml
+++ b/io.github.ilius.pyglossary.yml
@@ -1,6 +1,6 @@
 app-id: io.github.ilius.pyglossary
 runtime: org.gnome.Platform
-runtime-version: '47'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 command: pyglossary
 
@@ -10,25 +10,16 @@ finish-args:
   - --share=ipc
   - --talk-name=org.gtk.vfs.*
   - --filesystem=xdg-run/gvfsd
-
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/aclocal
+  - /share/doc
+  - /share/man
+  - '*.la'
+  - '*.a'
 modules:
-  - name: lzo
-    config-opts:
-      - --enable-shared
-      - --disable-static
-    cleanup:
-      - /include
-      - /share/doc
-      - '*.la'
-      - /lib/*.so
-    sources:
-      - type: archive
-        url: https://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz
-        sha256: c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072
-        x-checker-data:
-          type: anitya
-          project-id: 1868
-          url-template: https://www.oberhumer.com/opensource/lzo/download/lzo-$version.tar.gz
 
   - name: xapian-core
     config-opts:
@@ -38,8 +29,8 @@ modules:
       - --disable-documentation
     sources:
       - type: archive
-        sha256: bcbc99cfbf16080119c2571fc296794f539bd542ca3926f17c2999600830ab61
-        url: https://oligarchy.co.uk/xapian/1.4.27/xapian-core-1.4.27.tar.xz
+        sha256: 6cea3f49952a47224439a40bdb3608f928d121ad8721b9921cc42802d548ecf8
+        url: https://oligarchy.co.uk/xapian/2.0.0/xapian-core-2.0.0.tar.xz
         x-checker-data:
           type: anitya
           project-id: 15919
@@ -53,37 +44,35 @@ modules:
       - -Dtest_data_dir=none
     cleanup:
       - /bin
-      - /include
-      - /lib/pkgconfig
     sources:
       - type: git
         url: https://github.com/openzim/libzim.git
-        tag: 9.2.3
-        commit: 398a3c25059ee0ec7e2987d6af336d67dd681ba1
+        tag: 9.5.1
+        commit: 0f16c3cec3e86a42dbd5f6e0608f9c97412969e5
         x-checker-data:
           type: anitya
           project-id: 20193
           tag-template: $version
+
+  # flatpak_pip_generator --runtime='org.gnome.Sdk//50' --checker-data --requirements-file='requirements.txt' -o python3-modules
+  - python3-six.json
+  - python3-modules.json
 
   - name: pyglossary
     buildsystem: simple
     build-commands:
       - python3 setup.py build
       - python3 setup.py install "--prefix=${FLATPAK_DEST}"
-
       - desktop-file-edit --set-key=Exec --set-value="pyglossary --ui=gtk %U" --set-icon=${FLATPAK_ID}
         pkg/pyglossary.desktop
       - install -Dm644 pkg/pyglossary.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
       - install -Dm644 io.github.ilius.pyglossary.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
       - install -Dm644 res/pyglossary.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
-    modules:
-      # flatpak-pip-generator --runtime org.gnome.Sdk//46 --checker-data lxml beautifulsoup4 PyICU PyYAML marisa-trie libzim python-lzo html5li delocate prompt-toolkit
-      - python3-modules.json
     sources:
       - type: git
         url: https://github.com/ilius/pyglossary.git
-        tag: 5.0.7
-        commit: 9344a8f03a31c0f5898035dc34b47a38642dfb99
+        tag: 5.3.0
+        commit: 71475a2225e1e65ba9e21b43de34db8b3c3179a4
         x-checker-data:
           is-main-source: true
           type: anitya

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -4,19 +4,19 @@
     "build-commands": [],
     "modules": [
         {
-            "name": "python3-lxml",
+            "name": "python3-PyYAML",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"lxml\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyYAML\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/e7/6b/20c3a4b24751377aaa6307eb230b66701024012c29dd374999cc92983269/lxml-5.3.0.tar.gz",
-                    "sha256": "4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f",
+                    "url": "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz",
+                    "sha256": "d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f",
                     "x-checker-data": {
                         "type": "pypi",
-                        "name": "lxml"
+                        "name": "pyyaml"
                     }
                 }
             ]
@@ -30,8 +30,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/b1/fe/e8c672695b37eecc5cbf43e1d0638d88d66ba3a44c4d321c796f4e59167f/beautifulsoup4-4.12.3-py3-none-any.whl",
-                    "sha256": "b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed",
+                    "url": "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl",
+                    "sha256": "0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "beautifulsoup4",
@@ -40,121 +40,18 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d1/c2/fe97d779f3ef3b15f05c94a2f1e3d21732574ed441687474db9d342a7315/soupsieve-2.6-py3-none-any.whl",
-                    "sha256": "e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9",
+                    "url": "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl",
+                    "sha256": "ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "soupsieve",
                         "packagetype": "bdist_wheel"
                     }
-                }
-            ]
-        },
-        {
-            "name": "python3-PyICU",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyICU\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/52/21/4e9b0a3ace3027fc63107fa2b5d6e66e321e104da071d787856962fbad52/PyICU-2.14.tar.gz",
-                    "sha256": "acc7eb92bd5c554ed577249c6978450a4feda0aa6f01470152b3a7b382a02132",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "PyICU"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "python3-PyYAML",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyYAML\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz",
-                    "sha256": "d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "PyYAML"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "python3-marisa-trie",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"marisa-trie\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/31/15/9d9743897e4450b2de199ee673b50cb018980c4ced477d41cf91304a85e3/marisa_trie-1.2.1.tar.gz",
-                    "sha256": "3a27c408e2aefc03e0f1d25b2ff2afb85aac3568f6fa2ae2a53b57a2e87ce29d",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "marisa_trie"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "python3-delocate",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"delocate\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/4d/3f/3bc3f1d83f6e4a7fcb834d3720544ca597590425be5ba9db032b2bf322a2/altgraph-0.17.4-py2.py3-none-any.whl",
-                    "sha256": "642743b4750de17e655e6711601b077bc6598dbfa3ba5fa2b2a35ce12b508dff",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "altgraph",
-                        "packagetype": "bdist_wheel"
-                    }
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/bf/4a/aa78a0333ce108aa722a6b8f449dfae55b12ed180e98721a90e571896dbd/delocate-0.12.0-py3-none-any.whl",
-                    "sha256": "0da599c7561dcca2835149eaa4733e85408d71f249c6c4c43c3cb16cedb43a09",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "delocate",
-                        "packagetype": "bdist_wheel"
-                    }
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d1/5d/c059c180c84f7962db0aeae7c3b9303ed1d73d76f2bfbc32bc231c8be314/macholib-1.16.3-py2.py3-none-any.whl",
-                    "sha256": "0e315d7583d38b8c77e815b1ecbdbf504a8258d8b3e17b61165c6feb60d18f2c",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "macholib",
-                        "packagetype": "bdist_wheel"
-                    }
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl",
-                    "sha256": "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "packaging",
-                        "packagetype": "bdist_wheel"
-                    }
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl",
-                    "sha256": "04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                    "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",
+                    "sha256": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "typing_extensions",
@@ -164,43 +61,38 @@
             ]
         },
         {
-            "name": "python3-libzim",
+            "name": "python3-biplist",
             "buildsystem": "simple",
-            "build-options": {
-                "env": [
-                    "DONT_DOWNLOAD_LIBZIM=1",
-                    "USE_SYSTEM_LIBZIM=1"
-                ]
-            },
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"libzim\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"biplist\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/78/f6/11e18f0dc92a518b2e88c970a480e0832fc3b44efdb2bb95de5c1ea7e226/libzim-3.6.0.tar.gz",
-                    "sha256": "4dfc3a73e9e3c6e8f60a3b134f27069d74e96c4949c5aa20bb2ba994b00120be",
+                    "url": "https://files.pythonhosted.org/packages/3e/56/2db170a498c9c6545cda16e93c2f2ef9302da44802787b45a8a520d01bdb/biplist-1.0.3.tar.gz",
+                    "sha256": "4c0549764c5fe50b28042ec21aa2e14fe1a2224e239a1dae77d9e7f3932aa4c6",
                     "x-checker-data": {
                         "type": "pypi",
-                        "name": "libzim"
+                        "name": "biplist"
                     }
                 }
             ]
         },
         {
-            "name": "python3-python-lzo",
+            "name": "python3-colorize-pinyin",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"python-lzo\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"colorize-pinyin\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a4/8f/60cbc1a57257cd21c9e35217a8bc8713424dc7502df17794d914738df50f/python-lzo-1.15.tar.gz",
-                    "sha256": "a57aaa00c5c3a0515dd9f7426ba2cf601767dc19dc023d8b99d4a13b0a327b49",
+                    "url": "https://files.pythonhosted.org/packages/76/3e/9874fd764e982fec90d40dbf06cebdf449d62cc53fbdd6987f374a850066/colorize_pinyin-2.1.1-py3-none-any.whl",
+                    "sha256": "927fc1e18e9ae072d03e9573e25765a7f79feda00b1c5b2b03c4adf7f76a4293",
                     "x-checker-data": {
                         "type": "pypi",
-                        "name": "python-lzo"
+                        "name": "colorize_pinyin",
+                        "packagetype": "bdist_wheel"
                     }
                 }
             ]
@@ -224,6 +116,16 @@
                 },
                 {
                     "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl",
+                    "sha256": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "six",
+                        "packagetype": "bdist_wheel"
+                    }
+                },
+                {
+                    "type": "file",
                     "url": "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl",
                     "sha256": "a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
                     "x-checker-data": {
@@ -235,16 +137,114 @@
             ]
         },
         {
-            "name": "python3-prompt-toolkit",
+            "name": "python3-libzim",
             "buildsystem": "simple",
+            "build-options": {
+                "env": [
+                    "DONT_DOWNLOAD_LIBZIM=1",
+                    "USE_SYSTEM_LIBZIM=1"
+                ]
+            },
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"prompt-toolkit\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"libzim\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/e4/ea/d836f008d33151c7a1f62caf3d8dd782e4d15f6a43897f64480c2b8de2ad/prompt_toolkit-3.0.50-py3-none-any.whl",
-                    "sha256": "9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198",
+                    "url": "https://files.pythonhosted.org/packages/ae/98/207a1ad0ca10f4985a9e2c91a996b8bea40bbe1a3961a155c4a128459acd/libzim-3.9.0.tar.gz",
+                    "sha256": "4a0fdcce7f51fb49e65a3707baaaea63cd293dabb08d7d3b34ee0ef258534455",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "libzim"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-lxml",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"lxml\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz",
+                    "sha256": "cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "lxml"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-marisa-trie",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"marisa-trie\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d0/d0/048804753e2e5f12dd426e8badaa4a938a085cf00316df092b619863bef0/marisa_trie-1.4.0.tar.gz",
+                    "sha256": "20dd1a9035c5cb225c6eeb8e516ebced9497bf0b48d60e9b556f38d8cdf76df8",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "marisa_trie"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-mistune",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"mistune\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl",
+                    "sha256": "febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "mistune",
+                        "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-polib",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"polib\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/6b/99/45bb1f9926efe370c6dbe324741c749658e44cb060124f28dad201202274/polib-1.2.0-py2.py3-none-any.whl",
+                    "sha256": "1c77ee1b81feb31df9bca258cbc58db1bbb32d10214b173882452c73af06d62d",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "polib",
+                        "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-prompt_toolkit",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"prompt_toolkit\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl",
+                    "sha256": "9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "prompt_toolkit",
@@ -253,12 +253,106 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl",
-                    "sha256": "3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859",
+                    "url": "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl",
+                    "sha256": "1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "wcwidth",
                         "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-pyicu",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyicu\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b7/d5/354eb1bf84dcf4ab0bfa46f0620ecf68fe313bb082c26872ceb7a5021f94/pyicu-2.16.2.tar.gz",
+                    "sha256": "006d51e24b5ec76df6ec2130f3dde269c51db8b8cfebb7d45a427dde0d10aa52",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "pyicu"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-pymorphy3",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pymorphy3\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/84/3b/7fb4c1a8df59cb80f5f7ecb9646280e000f9ba2ccff8710205dc9aa4604f/dawg2_python-0.9.0-py3-none-any.whl",
+                    "sha256": "4fab6fc097bd176cd783cd8421b757348ea5a460789e53b0f6bb64831380bab5",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "dawg2_python",
+                        "packagetype": "bdist_wheel"
+                    }
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/18/4b/59bac03278033e293d1405ed42fb6c6252c25f40c50f509c615caeaa3b71/pymorphy3-2.0.6-py3-none-any.whl",
+                    "sha256": "0254317c02ce3ea17e080b7fc9d675e44662b3a5296bae68605b7a41d25b36c3",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "pymorphy3",
+                        "packagetype": "bdist_wheel"
+                    }
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b0/67/469e9e52d046863f5959928794d3067d455a77f580bf4a662630a43eb426/pymorphy3_dicts_ru-2.4.417150.4580142-py2.py3-none-any.whl",
+                    "sha256": "718bac64c73c10c16073a199402657283d9b64c04188b694f6d3e9b0d85440f4",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "pymorphy3_dicts_ru",
+                        "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-python-romkan-ng",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"python-romkan-ng\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/0d/86/58365a3fa110241b8373e2f3f1cabb8d13b488cb73e83870c769da189952/python_romkan_ng-0.3.0-py3-none-any.whl",
+                    "sha256": "4466a0c80d0cde9eefefbf017596ad7a77dc93068f95b2f8a2119ef5165887bc",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "python_romkan_ng",
+                        "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-xxhash",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"xxhash\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz",
+                    "sha256": "f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "xxhash"
                     }
                 }
             ]

--- a/python3-six.json
+++ b/python3-six.json
@@ -1,0 +1,19 @@
+{
+    "name": "python3-six",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"six\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl",
+            "sha256": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "six",
+                "packagetype": "bdist_wheel"
+            }
+        }
+    ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+PyYAML
+beautifulsoup4
+biplist
+colorize-pinyin
+html5lib
+libzim
+lxml
+marisa-trie
+mistune
+polib
+prompt_toolkit
+pyicu
+pymorphy3
+python-romkan-ng
+xxhash


### PR DESCRIPTION
- Update the runtime version to 50
- Update pyglossary version to 5.3.0
- Update dependencies
- Improve cleanup commands to reduce the Flatpak size

**No GUI, at the moment.**